### PR TITLE
Email Password Reset

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,6 +2,8 @@ import {
   Controller,
   Request,
   Post,
+  Get,
+  Param,
   UseGuards,
   Logger,
   Body,
@@ -21,6 +23,7 @@ import { RegisterDto } from './dto/register.dto';
 import { UsersService } from '../users/users.service';
 import { TokenDto } from './dto/token.dto';
 import { LoginDto } from './dto/login.dto';
+import { EmailPasswordResetDto } from './dto/email-password-reset.dto';
 import { HttpBadRequestResponse } from '../../errorHandling/httpBadRequestResponse.model';
 import { HttpConflictResponse } from '../../errorHandling/httpConflictResponse.model';
 
@@ -77,5 +80,38 @@ export class AuthController {
   async refreshToken(@Body() token: TokenDto): Promise<TokenDto> {
     // TODO
     return;
+  }
+
+  @Get('reset_email_password_initiate/:email')
+  @ApiOperation({ summary: 'Email password reset initiation' })
+  @ApiCreatedResponse({
+    description:
+      'If the email address exists, password reset was successfully triggered',
+  })
+  async resetEmailPasswordInitiate(
+    @Param('email') email: string,
+  ): Promise<null> {
+    const passwordResetToken = await this.usersService.createPasswordResetToken(
+      email,
+    );
+    if (passwordResetToken !== null) {
+      // TODO: actually send email with passwordResetToken
+    }
+    return;
+  }
+
+  @Post('reset_email_password_complete')
+  @ApiOperation({ summary: 'Email password reset initiation' })
+  @ApiCreatedResponse({
+    description:
+      'If the email address exists, password reset was successfully triggered',
+  })
+  async resetPasswordComplete(
+    @Body() payload: EmailPasswordResetDto,
+  ): Promise<TokenDto> {
+    const user = await this.usersService.updatePasswordIfResetTokenMatches(
+      payload,
+    );
+    return await this.authService.createToken(user);
   }
 }

--- a/src/modules/auth/dto/email-password-reset.dto.ts
+++ b/src/modules/auth/dto/email-password-reset.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+import { HttpBadRequestErrors } from 'src/errorHandling/httpBadRequestErrors.type';
+
+export class EmailPasswordResetDto {
+  @ApiProperty({ example: 'test@test.com' })
+  @IsEmail({}, { message: HttpBadRequestErrors.EMAIL_INVALID })
+  email!: string;
+
+  @IsNotEmpty()
+  passwordResetToken!: string;
+
+  @IsNotEmpty()
+  password!: string;
+}

--- a/src/modules/users/user.entity.ts
+++ b/src/modules/users/user.entity.ts
@@ -41,6 +41,12 @@ export class User extends AddressModel {
   @Exclude()
   password: string;
 
+  @ApiHideProperty()
+  @Column({ nullable: true })
+  @Exclude()
+  @IsOptional()
+  passwordResetToken?: string;
+
   @BeforeInsert()
   async hashPassword() {
     this.password = await bcrypt.hash(this.password, 10);


### PR DESCRIPTION
Summary: This commit implements an email driven password reset. The following endpoints are added:
* GET /auth/reset_email_password_initiate/:email - Creates a password reset token and sets it for a given email
* POST /auth/reset_email_password_complete {email,password,passwordResetToken} - If email and passwordResetToken match to the database entries, then the provided password is set. Otherwise a 404 error is thrown.

Test Plan:
curl /auth/reset_email_password_initiate/my_test_email@gmail.com
&gt; Status: 200
curl -X POST --header "Content-Type: application/json" -data '{"email":"my_test_email@gmail.com","passwordResetToken":"WRONG_TOKEN","password":"doesnt matter"}'
&gt; Status: 404
curl -X POST --header "Content-Type: application/json" -data '{"email":"my_test_email@gmail.com","passwordResetToken":"CORRECT_TOKEN","password":"some password"}'
&gt; Status 200
&gt; {"access_token": "..."}

What could be better?
* Password Reset Tokens have no TTL.
* Password Reset via phone is not possible.
* No email is actually sent, because I was not able to find the corresponding API to do so.