### PR TITLE
Toggled request logger middleware depending on node environment.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,14 +17,13 @@ async function bootstrap() {
   const globalPrefix = '/api/v1';
   setupSwagger(app, globalPrefix);
 
-  app.use(requestLoggerMiddleware);
-
   const appConfigService: ConfigurationService = app.get(
     'ConfigurationService',
   );
   const port = appConfigService.APIPort;
   const rootUrl = appConfigService.get('API_ROOT_URL');
 
+  app.use(requestLoggerMiddleware(appConfigService.isDev));
   app.enableCors();
   app.use(helmet());
 

--- a/src/middlewares/requestLogger.middleware.spec.ts
+++ b/src/middlewares/requestLogger.middleware.spec.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from 'express';
+import { requestLoggerMiddleware } from './requestLogger.middleware';
+
+const createRequestParams = () => ({
+  request: {
+    method: 'METHOD',
+    url: '/some-url',
+  } as Request,
+  response: {} as Response,
+  next: (jest.fn() as any) as NextFunction,
+});
+
+let log: jest.SpyInstance;
+let now: jest.SpyInstance;
+beforeEach(() => {
+  log = jest.spyOn(console, 'log').mockImplementation();
+  now = jest
+    .spyOn(global.Date, 'now')
+    .mockImplementation(() => new Date('2020-01-01T00:00:00.000Z').valueOf());
+});
+
+it('should log request when dev mode', () => {
+  const { response, request, next } = createRequestParams();
+  requestLoggerMiddleware(true)(request, response, next);
+
+  expect(log).toHaveBeenCalledWith('2020-01-01 00:00:00 ~ METHOD /some-url');
+
+  expect(next).toHaveBeenCalled();
+});
+
+it('should not log the request when not in dev mode', () => {
+  const { response, request, next } = createRequestParams();
+  requestLoggerMiddleware(false)(request, response, next);
+
+  expect(log).not.toHaveBeenCalled();
+
+  expect(next).toHaveBeenCalled();
+});
+
+afterEach(() => {
+  log.mockRestore();
+  now.mockRestore();
+});

--- a/src/middlewares/requestLogger.middleware.ts
+++ b/src/middlewares/requestLogger.middleware.ts
@@ -1,15 +1,16 @@
-import { NextFunction, RequestHandler } from 'express';
+import { RequestHandler } from 'express';
 import { parse } from 'url';
 
-export const requestLoggerMiddleware: RequestHandler = (
-  request: any,
-  response: any,
-  next: NextFunction,
-) => {
-  const { method } = request;
-  const date = new Date().toJSON();
-  const time = date.replace('T', ' ').slice(0, -5);
-  const route = parse(request.url).path;
-  console.log(`${time} ~ ${method} ${route || '/'}`); // tslint:disable-line no-console
+export const requestLoggerMiddleware: (
+  isDev: boolean,
+) => RequestHandler = isDev => (request, _response, next) => {
+  if (isDev) {
+    const { method } = request;
+    const date = new Date(Date.now()).toJSON();
+    const time = date.replace('T', ' ').slice(0, -5);
+    const route = parse(request.url).path;
+    console.log(`${time} ~ ${method} ${route || '/'}`); // tslint:disable-line no-console
+  }
+
   next();
 };


### PR DESCRIPTION
[GitHub issue](https://github.com/NexdApp/nexd-backend/issues/95)

Also added tests to request logger middleware.

Considered adding the isDev check in main.ts but figured it was better if non-production code was encapsulated in its own spot, rather than mixed with production code.